### PR TITLE
Change ReplaceAll to replace

### DIFF
--- a/function/string/replaceall.go
+++ b/function/string/replaceall.go
@@ -38,5 +38,5 @@ func (fnReplaceAll) Eval(params ...interface{}) (interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("string.replaceAll function third parameter [%+v] must be string", params[2])
 	}
-	return strings.ReplaceAll(s1, s2, s3), nil
+	return strings.Replace(s1, s2, s3, -1), nil
 }


### PR DESCRIPTION
`strings.ReplaceAll` method added after go 1.12.  If user use go version before Go1.12 which will have an issue to compile. 

Change `strings.ReplaceAll(s1, s2, s3)` to `strings.Replace(s1, s2, s3, -1)`, they are totally same.