### PR TITLE
Updated substring (end & start) params from string to int

### DIFF
--- a/function/string/descriptor.json
+++ b/function/string/descriptor.json
@@ -152,11 +152,11 @@
         },
         {
           "name": "start",
-          "type": "string"
+          "type": "int"
         },
         {
           "name": "end",
-          "type": "string"
+          "type": "int"
         }
       ],
       "return": {


### PR DESCRIPTION
End and start params for `substring` were defined as `string` type. This is causing errors at design time