### PR TITLE
fix(trigger):correct the homepage urls of channel & loadtester triggers.

### DIFF
--- a/trigger/channel/descriptor.json
+++ b/trigger/channel/descriptor.json
@@ -4,7 +4,7 @@
   "version": "0.9.0",
   "title": "Listen to Channel",
   "description": "Listens to Channel",
-  "homepage": "https://github.com/prject-flogo/contrib/tree/master/trigger/channel",
+  "homepage": "https://github.com/project-flogo/contrib/tree/master/trigger/channel",
   "settings": [
   ],
   "output": [

--- a/trigger/loadtester/descriptor.json
+++ b/trigger/loadtester/descriptor.json
@@ -4,7 +4,7 @@
   "version": "0.9.0",
   "title": "Load Tester",
   "description": "Simple Load Tester",
-  "homepage": "https://github.com/prject-flogo/contrib/tree/master/trigger/loadtester",
+  "homepage": "https://github.com/project-flogo/contrib/tree/master/trigger/loadtester",
   "settings": [
     {
       "name": "startDelay",


### PR DESCRIPTION
This corrects the typo in homepage urls of channel & loadtester triggers.