### PR TITLE
Fix compatible issue to avoid user app throw error.

### DIFF
--- a/function/datetime/current.go
+++ b/function/datetime/current.go
@@ -9,26 +9,26 @@ import (
 )
 
 
-type curremtFn struct {
+type currentFn struct {
 }
 
 func init() {
-	function.Register(&curremtFn{})
+	function.Register(&currentFn{})
 }
 
-func (s *curremtFn) Name() string {
+func (s *currentFn) Name() string {
 	return "current"
 }
 
-func (s *curremtFn) GetCategory() string {
+func (s *currentFn) GetCategory() string {
 	return "datetime"
 }
 
-func (s *curremtFn) Sig() (paramTypes []data.Type, isVariadic bool) {
+func (s *currentFn) Sig() (paramTypes []data.Type, isVariadic bool) {
 	return []data.Type{}, false
 }
 
-func (s *curremtFn) Eval(d ...interface{}) (interface{}, error) {
+func (s *currentFn) Eval(d ...interface{}) (interface{}, error) {
 	log.RootLogger().Debugf("Returns the current datetime with UTC timezone")
 	return time.Now().UTC(), nil
 }

--- a/function/datetime/current.go
+++ b/function/datetime/current.go
@@ -1,0 +1,34 @@
+package datetime
+
+import (
+	"github.com/project-flogo/core/data"
+	"github.com/project-flogo/core/support/log"
+	"time"
+
+	"github.com/project-flogo/core/data/expression/function"
+)
+
+
+type curremtFn struct {
+}
+
+func init() {
+	function.Register(&curremtFn{})
+}
+
+func (s *curremtFn) Name() string {
+	return "current"
+}
+
+func (s *curremtFn) GetCategory() string {
+	return "datetime"
+}
+
+func (s *curremtFn) Sig() (paramTypes []data.Type, isVariadic bool) {
+	return []data.Type{}, false
+}
+
+func (s *curremtFn) Eval(d ...interface{}) (interface{}, error) {
+	log.RootLogger().Debugf("Returns the current datetime with UTC timezone")
+	return time.Now().UTC(), nil
+}

--- a/function/datetime/current_test.go
+++ b/function/datetime/current_test.go
@@ -1,0 +1,21 @@
+package datetime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/project-flogo/core/data/expression/function"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	function.ResolveAliases()
+}
+
+func TestCurrentDate_Eval(t *testing.T) {
+	n := CurrentDatetime{}
+	datetime, _ := n.Eval(nil)
+	fmt.Println(datetime)
+	assert.NotNil(t, datetime)
+}
+

--- a/function/datetime/current_test.go
+++ b/function/datetime/current_test.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 func TestCurrentDate_Eval(t *testing.T) {
-	n := CurrentDatetime{}
+	n := currentFn{}
 	datetime, _ := n.Eval(nil)
 	fmt.Println(datetime)
 	assert.NotNil(t, datetime)

--- a/function/datetime/descriptor.json
+++ b/function/datetime/descriptor.json
@@ -159,7 +159,7 @@
             "example": "datetime.currentDate() => 2017-05-13+00:00",
             "args": [],
             "return": {
-                "type": "datetime"
+                "type": "string"
             }
         },
         {
@@ -168,7 +168,7 @@
             "example": "datetime.currentDatetime() => 2017-05-13T22:27:54+00:00",
             "args": [],
             "return": {
-                "type": "datetime"
+                "type": "string"
             }
         },
         {
@@ -177,7 +177,7 @@
             "example": "datetime.currentTime() => 22:27:54+00:00",
             "args": [],
             "return": {
-                "type": "datetime"
+                "type": "string"
             }
         },
         {

--- a/function/datetime/descriptor.json
+++ b/function/datetime/descriptor.json
@@ -154,6 +154,15 @@
             }
         },
         {
+            "name": "current",
+            "description": "Returns the current datetime with UTC timezone",
+            "example": "datetime.current() => 2020-04-21T03:16:44+00:00",
+            "args": [],
+            "return": {
+                "type": "datetime"
+            }
+        },
+        {
             "name": "currentDate",
             "description": "Returns the current date with UTC time zone.",
             "example": "datetime.currentDate() => 2017-05-13+00:00",
@@ -283,7 +292,7 @@
             "example": "datetime.now() => 2017-05-13T15:59:41+00:00",
             "args": [],
             "return": {
-                "type": "datetime"
+                "type": "string"
             }
         },
         {


### PR DESCRIPTION
This PR use to revert the last fix when we adding new DateTime functions.  

Change type back to a string to avoid break exist user app.   The user still can use to datatime.parse function to convert it to datetime type. 