### PR TITLE
add example to make sure type match

### DIFF
--- a/function/datetime/descriptor.json
+++ b/function/datetime/descriptor.json
@@ -8,7 +8,7 @@
         {
             "name": "add",
             "description": "Add the given number of years, months and days to the DateTime",
-            "example": "datetime.format(datetime.add(\"2020-03-19T15:02:03Z\", 1,1, 3), \"RFC3339\")  => 2021-04-22T15:02:03Z",
+            "example": "datetime.addHours(datetime.current(), 3) => 2021-05-30T16:38:55.34586567Z",
             "args": [
                 {
                     "name": "datetime",
@@ -40,7 +40,7 @@
         {
             "name": "addHours",
             "description": "Add the given number of hours to the DateTime",
-            "example": "datetime.format(datetime.addHours(\"2020-03-19T15:02:03\", 3), \"RFC3339\")  => 2020-03-19T18:02:03Z",
+            "example": "datetime.addHours(datetime.current(), 3) => 2020-04-27T19:38:55.345832054Z",
             "args": [
                 {
                     "name": "datetime",
@@ -62,7 +62,7 @@
         {
             "name": "addMins",
             "description": "Add the given number of mins to the DateTime",
-            "example": "datetime.format(datetime.addMins(\"2020-03-19T15:02:03\", 30), \"RFC3339\")  => 2020-03-19T19:32:03Z",
+            "example": "datetime.addMins(datetime.current(), 30) => 2020-04-27T17:08:55.345841684Z",
             "args": [
                 {
                     "name": "datetime",
@@ -84,7 +84,7 @@
         {
             "name": "addSeconds",
             "description": "Add the given number of seconds to the DateTime",
-            "example": "datetime.format(datetime.addSeconds(\"2020-03-19T15:02:03\", 30), \"RFC3339\")  => 2020-03-19T18:02:33Z",
+            "example": "datetime.addSeconds(datetime.current(), 30) => 2020-04-27T16:39:25.345860393Z",
             "args": [
                 {
                     "name": "datetime",
@@ -106,7 +106,7 @@
         {
             "name": "create",
             "description": "Create date by given year, months, days, hours, mins, seconds, nanoseconds and timezone,  the timezone follow the IANA Time Zone",
-            "example": "datetime.format(datetime.create(2020,1,3,2,22,0, \"America/Los_Angeles\"), \"RFC3339\") => 2020-01-03T02:22:00-08:00",
+            "example": "datetime.create(2020,1,3,2,22,0,0, \"America/Los_Angeles\") => 2020-01-03T02:22:00-08:00",
             "args": [
                 {
                     "name": "years",
@@ -192,7 +192,7 @@
         {
             "name": "diff",
             "description": "Return the difference between two given DateTime, the difference controlled by argument type, the type in (days,hours,mins and seconds)",
-            "example": "datetime.diff(\"2020-03-19T15:02:03\",\"2020-03-18:02:03\", \"hours\")  => 3",
+            "example": "datetime.diff(datetime.current(), datetime.addHours(datetime.current(), 2), \"hours\") => 2",
             "args": [
                 {
                     "name": "start",
@@ -217,7 +217,7 @@
         {
             "name": "format",
             "description": "Format the date according to the specified format. The format uses MM(month), DD(day), YYYY(year), hh(hour), mm(minute) and ss(second), they are case insensitive except MM. it also can format with predefine layout ANSIC, UnixDate, RubyDate, RFC822, RFC822Z, RFC850, RFC1123, RFC1123Z, RFC3339 and RFC3339Nano",
-            "example": "datetime.format（\"02/08/2017\", \"dd-MM-yyyy\"）=> 08-02-2017",
+            "example": "datetime.format(datetime.current(), \"RFC3339\")=> 2020-04-27T16:38:45Z",
             "args": [
                 {
                     "name": "datetime",
@@ -298,7 +298,7 @@
         {
             "name": "parse",
             "description": "Parse the given datetime to the DateTime with time zone, default base on UTC and timezone follow the IANA Time Zone ",
-            "example": "datetime.format(datetime.addSeconds(\"2020-03-19T15:02:03+06:00\", \"America/Los_Angeles\"), \"RFC3339\")  => 2020-03-19T02:02:03-07:00",
+            "example": "datetime.parse(\"2020-03-19T15:02:03+06:00\", \"America/Los_Angeles\") => 2020-03-19T02:02:03-07:00",
             "args": [
                 {
                     "name": "str",
@@ -320,7 +320,7 @@
         {
             "name": "sub",
             "description": "Subtract the given number of years, months and days from the DateTime",
-            "example": "datetime.format(datetime.sub(\"2020-03-19T15:02:03\", 1,1,1), \"RFC3339\") => 2019-02-18T15:02:03Z",
+            "example": "datetime.sub(datetime.current(), 1,1,1) => 2019-03-26T16:38:55.345876511Z",
             "args": [
                 {
                     "name": "datetime",
@@ -352,7 +352,7 @@
         {
             "name": "subHours",
             "description": "Subtract the given number of hours from the DateTime",
-            "example": "datetime.format(datetime.subHours(\"2020-03-19T15:02:03\",1), \"RFC3339\")  => 2020-03-19T14:02:03Z",
+            "example": "datetime.subHours(datetime.current(),1) => 2020-04-27T15:38:55.345861378Z",
             "args": [
                 {
                     "name": "datetime",
@@ -373,7 +373,7 @@
         {
             "name": "subMins",
             "description": "Subtract the given number of minutes from the DateTime",
-            "example": "datetime.format(datetime.subMins(\"2020-03-19T15:02:03\",10), \"RFC3339\")  => 2020-03-19T14:52:03Z",
+            "example": "datetime.subMins(datetime.current(),10) => 2020-04-27T16:28:55.345864058Z",
             "args": [
                 {
                     "name": "datetime",
@@ -394,7 +394,7 @@
         {
             "name": "subSeconds",
             "description": "Subtract the given number of seconds from the DateTime",
-            "example": "datetime.format(datetime.subSeconds(\"2020-03-19T15:02:03\",10), \"RFC3339\")  => 2020-03-19T15:01:53Z",
+            "example": "datetime.subSeconds(datetime.current(),10) => 2020-04-27T16:38:45.346028182Z",
             "args": [
                 {
                     "name": "datetime",


### PR DESCRIPTION
Fixed #120 

An example field should have the correct type, the string cannot assign to datatype as it is a type mismatch.

