### PR TITLE
Correcting error handling

### DIFF
--- a/activity/jsexec/activity.go
+++ b/activity/jsexec/activity.go
@@ -73,7 +73,7 @@ func (a *Activity) Eval(ctx activity.Context) (done bool, err error) {
 	if err != nil {
 		output.Error = true
 		output.ErrorMessage = err.Error()
-		return false, err
+		return true, nil
 	}
 	output.Result = result
 


### PR DESCRIPTION
For errors returned by the script, activity should not fail.