### PR TITLE
Add http proxy cababitlity for rest-trigger

### DIFF
--- a/trigger/rest/README.md
+++ b/trigger/rest/README.md
@@ -1,115 +1,49 @@
-<!--
-title: REST
-weight: 4706
--->
 # REST Trigger
 This trigger provides your flogo application the ability to start an action via REST over HTTP
-
+If the option `isPassThroughUri` is set, a pathParam is automatically create with the rest of the path after the give settings path of the handler
 ## Installation
 
 ```bash
 flogo install github.com/project-flogo/contrib/trigger/rest
 ```
 
+## TIBCO sandbox - Manual loading
+```bash
+zip the 'rest' directory (including the directory 'rest' )
+Go to https://eu.integration.cloud.tibco.com/envtools/flogo_extensions and upload the zip
+ensure to increase the version nr in the description.json before uploading to distingues between versions
+```
+
 ## Configuration
 
 ### Settings:
-| Name      | Type   | Description
-|:---       | :---   | :---       
-| port      | int    | The port to listen on - **REQUIRED**
-| enableTLS | bool   | Enable TLS on the server
-| certFile  | string | The path to PEM encoded server certificate
-| keyFile   | string | The path to PEM encoded server key
-
+| Name      | Type   | Description                                |
+|:----------|:-------|:-------------------------------------------|
+| port      | int    | The port to listen on - **REQUIRED**       |
+| enableTLS | bool   | Enable TLS on the server                   |
+| certFile  | string | The path to PEM encoded server certificate |
+| keyFile   | string | The path to PEM encoded server key         |
 
 ### Handler Settings:
-| Name     | Type   | Description
-|:---      | :---   | :---          
-| method   | string | The HTTP method (ie. GET,POST,PUT,PATCH or DELETE) - **REQUIRED**
-| path     | string | The resource path - **REQUIRED**
+| Name       | Type    | Description                                                        |
+|:-----------|:--------|:-------------------------------------------------------------------|
+| method     | string  | The HTTP method (ie. GET,POST,PUT,PATCH or DELETE) - **REQUIRED**  |
+| path       | string  | The resource path - **REQUIRED**                                   |
+
 
 ### Output:
-| Name        | Type   | Description
-|:---         | :---   | :---        
-| pathParams  | params | The path parameters (e.g., 'id' in http://.../pet/:id/name )
-| queryParams | params | The query parameters (e.g., 'id' in http://.../pet?id=someValue )
-| headers     | params | The HTTP header parameters
-| method      | string  | The HTTP method used for the request
-| content     | any    | The content of the request
+| Name        | Type   | Description                                                       |
+|-------------|--------|-------------------------------------------------------------------|
+| pathParams  | params | The path parameters (e.g., 'id' in http://.../pet/:id/name )      |
+| queryParams | params | The query parameters (e.g., 'id' in http://.../pet?id=someValue ) |
+| headers     | params | The HTTP header parameters                                        |
+| method      | string | The HTTP method used for the request                              |
+| content     | any    | The content of the request                                        |
 
 ### Reply:
-| Name    | Type   | Description
-|:---     | :---   | :---        
-| code    | int    | The http code to reply with
-| data    | any    | The data to reply with
-| headers | params | The HTTP response headers
-| cookies | params | The HTTP response cookies to set (uses 'Set-Cookie' headers)
-
-## Example Configurations
-
-Triggers are configured via the triggers.json of your application. The following are some example configuration of the REST Trigger.
-
-### POST
-Configure the Trigger to handle a POST on /device
-
-```json
-{
-  "triggers": [
-    {
-      "id": "flogo-rest",
-      "ref": "github.com/project-flogo/contrib/trigger/rest",
-      "settings": {
-        "port": 8080
-      },
-      "handlers": [
-        {
-          "settings": {
-            "method": "POST",
-            "path": "/device"
-          },
-          "action": {
-            "ref": "github.com/project-flogo/flow",
-            "settings": {
-              "flowURI": "res://flow:new_device_flow"
-            }
-          }
-        }
-      ]
-    }
-  ]
-}
-```
-
-### GET
-Configure the Trigger to handle a GET on /device/:id
-
-```json
-{
-  "triggers": [
-    {
-      "id": "flogo-rest",
-      "ref": "github.com/project-flogo/contrib/trigger/rest",
-      "settings": {
-        "port": 8080
-      },
-      "handlers": [
-        {
-          "settings": {
-            "method": "GET",
-            "path": "/device/:id"
-          },
-          "action": {
-            "ref": "github.com/project-flogo/flow",
-            "settings": {
-              "flowURI": "res://flow:get_device_flow"
-            },
-            "input":{
-              "deviceId":"=$.pathParams.id"
-            }
-          }
-        }
-      ]
-    }
-  ]
-}
-```
+| Name    | Type   | Description                                                  |
+|---------|--------|--------------------------------------------------------------|
+| code    | int    | The http code to reply with                                  |
+| data    | any    | The data to reply with                                       |
+| headers | params | The HTTP response headers                                    |
+| cookies | params | The HTTP response cookies to set (uses 'Set-Cookie' headers) |

--- a/trigger/rest/descriptor.json
+++ b/trigger/rest/descriptor.json
@@ -1,10 +1,10 @@
 {
-  "name": "flogo-rest",
+  "name": "flogo-lp-rest",
   "type": "flogo:trigger",
-  "version": "0.10.0",
-  "title": "Receive HTTP Message",
-  "description": "Simple REST Trigger",
-  "homepage": "https://github.com/project-flogo/contrib/tree/master/trigger/rest",
+  "version": "1.0.0",
+  "title": "HTTP uri-path pass through",
+  "description": "Rest Trigger with uri-path pass through capabilities ",
+  "homepage": "https://gitlab.core-services.leaseplan.systems/workloads/0026-wkl-ng-integration/integration/shared/flogoresttrigger",
   "settings": [
     {
       "name": "port",
@@ -58,7 +58,7 @@
   "reply": [
     {
       "name": "code",
-      "type": "int",
+      "type": "number",
       "description": "The http code to reply with"
     },
     {
@@ -79,6 +79,13 @@
   ],
   "handler": {
     "settings": [
+      {
+        "name": "isPassThroughUri",
+        "type": "string",
+        "required" : true,
+        "allowed" : ["YES", "NO"],
+        "description": "use as a pass through will automatically add a 'partial' part of the defined 'path' as a pathParam with name 'restOfThePath'"
+      },
       {
         "name": "method",
         "type": "string",

--- a/trigger/rest/metadata.go
+++ b/trigger/rest/metadata.go
@@ -12,8 +12,9 @@ type Settings struct {
 }
 
 type HandlerSettings struct {
-	Method string `md:"method,required,allowed(GET,POST,PUT,PATCH,DELETE)"` // The HTTP method (ie. GET,POST,PUT,PATCH or DELETE)
-	Path   string `md:"path,required"`                                      // The resource path
+	IsPassThroughUri string `md:"isPassThroughUri,required,allowed(YES,NO)"`          // use as a pass through will automatically add a 'partial' part of the defined 'path' as a pathParam with name 'restOfThePath'
+	Method           string `md:"method,required,allowed(GET,POST,PUT,PATCH,DELETE)"` // The HTTP method (ie. GET,POST,PUT,PATCH or DELETE)
+	Path             string `md:"path,required"`                                      // The resource path
 }
 
 type Output struct {

--- a/trigger/rest/server.go
+++ b/trigger/rest/server.go
@@ -12,20 +12,20 @@ import (
 )
 
 const (
-	httpDefaultAddr = ":http" //todo should this be :8080
+	httpDefaultAddr    = ":http"  //todo should this be :8080
 	httpDefaultTlsAddr = ":https" //todo should this be :8443
 
-	httpDefaultReadTimeout = 15 * time.Second
+	httpDefaultReadTimeout  = 15 * time.Second
 	httpDefaultWriteTimeout = 15 * time.Second
 )
 
 type Server struct {
 	running bool
-	srv *http.Server
+	srv     *http.Server
 
 	tlsEnabled bool
-	certFile string
-	keyFile string
+	certFile   string
+	keyFile    string
 }
 
 func NewServer(addr string, handler http.Handler, opts ...func(*Server)) (*Server, error) {
@@ -36,10 +36,10 @@ func NewServer(addr string, handler http.Handler, opts ...func(*Server)) (*Serve
 
 	srv := &Server{}
 	srv.srv = &http.Server{
-		Addr: addr,
-		Handler: handler,
-		ReadTimeout:httpDefaultReadTimeout,
-		WriteTimeout:httpDefaultWriteTimeout,
+		Addr:         addr,
+		Handler:      handler,
+		ReadTimeout:  httpDefaultReadTimeout,
+		WriteTimeout: httpDefaultWriteTimeout,
 	}
 
 	for _, opt := range opts {
@@ -52,7 +52,6 @@ func NewServer(addr string, handler http.Handler, opts ...func(*Server)) (*Serve
 
 	return srv, nil
 }
-
 
 ///////////////////////
 // Options
@@ -145,7 +144,7 @@ func (s *Server) Stop() error {
 ///////////////////////
 // Validation Helpers
 
-func (s *Server) validateStart()  error {
+func (s *Server) validateStart() error {
 
 	//check if port is available
 	ln, err := net.Listen("tcp", s.srv.Addr)
@@ -157,7 +156,7 @@ func (s *Server) validateStart()  error {
 	return nil
 }
 
-func (s *Server) validateInit()  error {
+func (s *Server) validateInit() error {
 
 	if s.tlsEnabled {
 		// using tls, so validate cert & key


### PR DESCRIPTION
Pass Through Proxy

The idea is to have the REST Trigger and REST activity (https://github.com/project-flogo/contrib/tree/master/activity/rest)
changed in such away, that there is a possiblity to create a flogo app that has pass through proxy functionalities.

CHANGES TRIGGER:
    Handle the existing functionality of create a path variable of the last part of the url coming in of the trigger (github.com/julienschmidt/httprouter):
    example: incoming url: http://tibco.org/path/that/comes/in  definition in trigger: /:restOfPath will
             define a pathParams  key: 'restOfPath' value: 'path/that/comes/in'
    This :restOfPath definition in the trigger will also be exposed to the outside world e.g. mashery.
    In mashery there is no option to change this mapping, therefore the trigger needs to be changed to automatically
    create the 'restOfPath' variable for the rest of the path as defined in the trigger.
    It will do so, using a boolean 'isPassThrough' to be able to turn this functionality on/off
